### PR TITLE
Refactors pageTitled onlyOneH1 rule to maximumTwoH1 

### DIFF
--- a/build/lib/rules/pageTitled.js
+++ b/build/lib/rules/pageTitled.js
@@ -36,10 +36,10 @@ var pageTitled = {
     }
   }),
 
-  onlyOneH1: new Rule({
+  maximumTwoH1: new Rule({
     name:    'No more than two h1 elements',
 
-    message: 'A document can only contain one H1 element',
+    message: 'A document can contain no more than two H1 elements',
 
     ruleUrl: 'http://oaa-accessibility.org/rule/17/',
 
@@ -57,7 +57,7 @@ var pageTitled = {
         e.push(this);
       });
 
-      if (e.length > 1) {
+      if (e.length > 2) {
         reporter.error(that.message, 0, that.name);
         throw dom.$(this).parent().html();
       }

--- a/lib/rules/pageTitled.js
+++ b/lib/rules/pageTitled.js
@@ -36,10 +36,10 @@ var pageTitled = {
     }
   }),
 
-  onlyOneH1: new Rule({
+  maximumTwoH1: new Rule({
     name:    'No more than two h1 elements',
 
-    message: 'A document can only contain one H1 element',
+    message: 'A document can contain no more than two H1 elements',
 
     ruleUrl: 'http://oaa-accessibility.org/rule/17/',
 
@@ -57,7 +57,7 @@ var pageTitled = {
         e.push(this);
       });
 
-      if (e.length > 1) {
+      if (e.length > 2) {
         reporter.error(that.message, 0, that.name);
         throw dom.$(this).parent().html();
       }


### PR DESCRIPTION
Changing the onlyOneH1 rule to match the description of the rule as stated in the URL shown. 

http://oaa-accessibility.org/rule/17/

Renamed onlyOneH1 to maximumTwoH1, updated the message and length check accordingly.

Resolves globant-ui/arialinter#13
