### PR TITLE
Fixes linkPurpose.linkHasMoreThan4Chars issue

### DIFF
--- a/build/lib/rules/linkPurpose.js
+++ b/build/lib/rules/linkPurpose.js
@@ -9,12 +9,12 @@
 var Rule = require('../rule').Rule;
 
 var linkPurpose = {
-  linksMoreThan4Chars: new Rule({
+  linksAtLeast4Chars: new Rule({
     name:    'Link text should be as least four 4 characters long',
 
-    message: 'The links should have more than 4 characters',
+    message: 'The links should have 4 or more characters',
 
-    ruleUrl: '',
+    ruleUrl: 'http://www.openajax.org/member/wiki/Accessibility_-_WCAG20_Validation_Rules',
 
     level: 'A',
 
@@ -26,7 +26,7 @@ var linkPurpose = {
       var that = this;
 
       dom.$('a').each(function() {
-        if (dom.$(this).text().length <= 4) {
+        if (dom.$(this).text().length < 4) {
           reporter.error(that.message, 0, that.name);
           throw dom.$(this).parent().html();
         }

--- a/lib/rules/linkPurpose.js
+++ b/lib/rules/linkPurpose.js
@@ -9,12 +9,12 @@
 var Rule = require('../rule').Rule;
 
 var linkPurpose = {
-  linksMoreThan4Chars: new Rule({
+  linksAtLeast4Chars: new Rule({
     name:    'Link text should be as least four 4 characters long',
 
-    message: 'The links should have more than 4 characters',
+    message: 'The links should have 4 or more characters',
 
-    ruleUrl: '',
+    ruleUrl: 'http://www.openajax.org/member/wiki/Accessibility_-_WCAG20_Validation_Rules',
 
     level: 'A',
 
@@ -26,7 +26,7 @@ var linkPurpose = {
       var that = this;
 
       dom.$('a').each(function() {
-        if (dom.$(this).text().length <= 4) {
+        if (dom.$(this).text().length < 4) {
           reporter.error(that.message, 0, that.name);
           throw dom.$(this).parent().html();
         }


### PR DESCRIPTION
Fixes issue globant-ui/arialinter#15 where link should have At Least 4 Characters, not more than 4.

Match the rule as stated in http://www.openajax.org/member/wiki/Accessibility_-_WCAG20_Validation_Rules.  Including Rule URL in the definition.  Updating message text to be "4 or more" characters versus "more than 4"
