### PR TITLE
Modified rule to support an empty alt attribute

### DIFF
--- a/lib/rules/textAlternatives.js
+++ b/lib/rules/textAlternatives.js
@@ -17,7 +17,7 @@
 
       callback: function(dom) {
         dom.$('img').each(function() {
-          if (!dom.$(this).attr('alt')) {
+          if (typeof dom.$(this).attr('alt') === 'undefined') {
             throw {
               reportType: 'error',
               el: dom.$(this).parent().html()

--- a/test/rules/textAlternatives/haveEmptyAltAttr.html
+++ b/test/rules/textAlternatives/haveEmptyAltAttr.html
@@ -1,0 +1,2 @@
+<img src="http://dummyimage.com/600x400.gif/292929/e3e3e3" alt="" />
+<img src="http://dummyimage.com/600x400.gif/292929/e3e3e3" alt="asd" />

--- a/test/rules/textAlternatives/textAlternatives_test.js
+++ b/test/rules/textAlternatives/textAlternatives_test.js
@@ -14,6 +14,15 @@ exports['textAlternatives rules'] = {
       test.notEqual(rule.applyRule(window), true, 'Should fail because images dont have alt attribute');
       test.done();
     });
+  },
+
+  'HaveEmptyAltAttr': function(test) {
+    var rule = RuleRegistry.getRule('validAltText');
+
+    jsdom.env('test/rules/textAlternatives/haveEmptyAltAttr.html', ['http://code.jquery.com/jquery.js'], function (err, window) {
+      test.equal(rule.applyRule(window), true, 'Should pass because images have empty or non-empty alt attributes');
+      test.done();
+    });
   }
 
 }


### PR DESCRIPTION
Images may have an empty alt attribute if it's used for cosmetic purposes.

From http://www.w3.org/TR/html4/struct/objects.html#adef-alt :

"Do not specify irrelevant alternate text when including images intended to format a page, for instance, alt="red ball" would be inappropriate for an image that adds a red ball for decorating a heading or paragraph. In such cases, the alternate text should be the empty string ("")."
