### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-###--This Package has been **deprecated** as we can not longer mantain it.--
+### --This Package has been **deprecated** as we can not longer mantain it.--
 
 AriaLinter [![Build Status](https://api.travis-ci.org/globant-ui/arialinter.png?branch=master)](http://travis-ci.org/globant-ui/arialinter) ![Dependencies](https://david-dm.org/globant-ui/arialinter.png)
 ============
@@ -123,13 +123,13 @@ Execute the linter using all the rules of the level A and the rules that just ap
 $ arialinter --level A --templates test/testFiles/index.html
 ```
 
-##Related projects:
+## Related projects:
 * [A11YLint](https://github.com/DuaneOBrien/A11YLint-Brackets). A11YLint is an extension for the Brackets IDE which
 aims to bring the same kind of in-context, immediate feedback that you get from JSLint/JSHint and other linting tools,
 but regarding issues in your HTML that would affect how accessible your content is.
 * [gulp-arialinter](https://github.com/Charca/gulp-arialinter). Gulp plugin for the accessibility tool AriaLinter.
 
-##Resources:
+## Resources:
 * Accessibility
  * WAI-ARIA Authoring Practices: http://www.w3.org/TR/wai-aria-practices/
  * http://www.w3.org/TR/WCAG20-TECHS/html.html
@@ -137,7 +137,7 @@ but regarding issues in your HTML that would affect how accessible your content 
  * https://dvcs.w3.org/hg/aria-unofficial/raw-file/tip/index.html
  * http://www.openajax.org/member/wiki/Accessibility_-_WCAG20_Validation_Rules
 
-##License
+## License
 
 Copyright (c) 2013 Globant UI Developers
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
